### PR TITLE
Generate code to call childrenListener using name instead of toString

### DIFF
--- a/data_classes_generator/lib/data_classes_generator.dart
+++ b/data_classes_generator/lib/data_classes_generator.dart
@@ -298,7 +298,7 @@ class DataClassGenerator extends GeneratorForAnnotation<DataClass> {
         '    final prevValue = get(prev);',
         '    final nextValue = get(next);',
         '    if (!eqShallow(nextValue, prevValue)) {',
-        '      await $childrenListener(',
+        '      await ${childrenListener.name}(',
         "        '$objectNamePrefix\$name',",
         '        next: nextValue,',
         '        prev: prevValue,',


### PR DESCRIPTION
The toString function of a function `ExecutableElement` includes the return type of the function so when used here it caused a syntax error.