### PR TITLE
Add deserialize dates as utc flag

### DIFF
--- a/data_classes/lib/data_classes.dart
+++ b/data_classes/lib/data_classes.dart
@@ -21,6 +21,7 @@ class DataClass {
     this.childrenListener,
     this.convertToSnakeCase = false,
     this.copyWith = true,
+    this.deserializeDatesAsUtc = false,
     this.getName,
     this.immutable = false,
     this.listener,
@@ -31,6 +32,7 @@ class DataClass {
   final ChangeListener? childrenListener;
   final bool convertToSnakeCase;
   final bool copyWith;
+  final bool deserializeDatesAsUtc;
   final Function? getName;
   final bool immutable;
   final String? name;
@@ -193,8 +195,10 @@ bool? boolValueFromJson(dynamic json) {
   return str == 'true' || str == 'false' ? false : null;
 }
 
-DateTime? dateTimeValueFromJson(dynamic json) =>
-    DateTime.tryParse(castOrNull<String>(json) ?? '');
+DateTime? dateTimeValueFromJson(dynamic json, {bool convertToUtc = false}) {
+  final date = DateTime.tryParse(castOrNull<String>(json) ?? '');
+  return convertToUtc ? date?.toUtc() : date;
+}
 
 double? doubleValueFromJson(dynamic json) => json == null
     ? null

--- a/data_classes/lib/data_classes.dart
+++ b/data_classes/lib/data_classes.dart
@@ -195,9 +195,15 @@ bool? boolValueFromJson(dynamic json) {
   return str == 'true' || str == 'false' ? false : null;
 }
 
-DateTime? dateTimeValueFromJson(dynamic json, {bool convertToUtc = false}) {
-  final date = DateTime.tryParse(castOrNull<String>(json) ?? '');
-  return convertToUtc ? date?.toUtc() : date;
+DateTime? dateTimeValueFromJson(dynamic json, {bool asUtc = false}) {
+  String? dateStr = castOrNull<String>(json);
+  if (dateStr == null) return null;
+
+  if (asUtc && !dateStr.endsWith('Z')) {
+    dateStr = '${dateStr}${!dateStr.contains('T') ? 'T00:00:00' : ''}Z';
+  }
+
+  return DateTime.tryParse(dateStr);
 }
 
 double? doubleValueFromJson(dynamic json) => json == null

--- a/data_classes_generator/lib/data_classes_generator.dart
+++ b/data_classes_generator/lib/data_classes_generator.dart
@@ -108,6 +108,9 @@ class DataClassGenerator extends GeneratorForAnnotation<DataClass> {
         classAnnotation.getField('immutable')!.toBoolValue()!;
     final bool convertToSnakeCase =
         classAnnotation.getField('convertToSnakeCase')?.toBoolValue() ?? false;
+    final bool deserializeDatesAsUtc =
+        classAnnotation.getField('deserializeDatesAsUtc')?.toBoolValue() ??
+            false;
     // final ExecutableElement listener = originalClass.metadata
     //     .firstWhere((annotation) =>
     //         annotation.element?.enclosingElement?.name == 'DataClass')
@@ -258,6 +261,7 @@ class DataClassGenerator extends GeneratorForAnnotation<DataClass> {
           ...generateFieldDeserializer(
             field,
             convertToSnakeCase: convertToSnakeCase,
+            deserializeDatesAsUtc: deserializeDatesAsUtc,
           ),
         '\n  return model;',
         '}',

--- a/data_classes_generator/lib/deserialization.dart
+++ b/data_classes_generator/lib/deserialization.dart
@@ -19,6 +19,7 @@ List<String> generateFieldDeserializer(
   final String? deserializer = _generateValueDeserializer(
     accessor: 'j',
     customDeserializer: field.customDeserializer,
+    deserializeDatesAsUtc: deserializeDatesAsUtc,
     fieldType: type,
   );
 
@@ -69,7 +70,9 @@ String? _generateValueDeserializer({
                       : fieldType.isDartCoreDouble
                           ? 'doubleValueFromJson($accessor)'
                           : fieldType.isDateTime
-                              ? 'dateTimeValueFromJson($accessor, convertToUtc: $deserializeDatesAsUtc)'
+                              ? 'dateTimeValueFromJson($accessor'
+                                  '${deserializeDatesAsUtc ? ', asUtc: true' : ''}'
+                                  ')'
                               : fieldType.isEnum
                                   ? 'enumValueFromJson($accessor, $typeStr.values)'
                                   : fieldType.hasFromJson

--- a/data_classes_generator/lib/deserialization.dart
+++ b/data_classes_generator/lib/deserialization.dart
@@ -9,6 +9,7 @@ import 'package:data_classes/data_classes.dart';
 List<String> generateFieldDeserializer(
   FieldElement field, {
   bool convertToSnakeCase = false,
+  bool deserializeDatesAsUtc = false,
 }) {
   final DartType type = field.type;
   final String fieldName =
@@ -37,6 +38,7 @@ String? _generateValueDeserializer({
   required String accessor,
   required DartType fieldType,
   String? customDeserializer,
+  bool deserializeDatesAsUtc = false,
 }) {
   late String typeStr;
   if (fieldType.hasFromJson || fieldType.isEnum) {
@@ -67,7 +69,7 @@ String? _generateValueDeserializer({
                       : fieldType.isDartCoreDouble
                           ? 'doubleValueFromJson($accessor)'
                           : fieldType.isDateTime
-                              ? 'dateTimeValueFromJson($accessor)'
+                              ? 'dateTimeValueFromJson($accessor, convertToUtc: $deserializeDatesAsUtc)'
                               : fieldType.isEnum
                                   ? 'enumValueFromJson($accessor, $typeStr.values)'
                                   : fieldType.hasFromJson


### PR DESCRIPTION
This is used on the tests so have to specify the time in the test files for it to be converted to UTC. It makes the test files shorter and easier to read by turning entries like `12-01-2020T00:00:00Z` into `12-01-2020` which removes a lot of noise from the test files.